### PR TITLE
prepare .com domain cutover

### DIFF
--- a/app/(notes)/[slug]/layout.tsx
+++ b/app/(notes)/[slug]/layout.tsx
@@ -13,6 +13,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: post.title,
     description: post.description,
+    alternates: {
+      canonical: post.canonicalUrl,
+    },
+    openGraph: {
+      url: post.canonicalUrl,
+    },
   };
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Analytics } from "@vercel/analytics/react";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Cormorant_Garamond } from "next/font/google";
+import { site } from "@/constants";
 import { Footer } from "@/components/footer";
 import "./globals.css";
 
@@ -21,9 +22,13 @@ const cormorantGaramond = Cormorant_Garamond({
 });
 
 export const metadata: Metadata = {
-  title: "williamhzo.me",
+  metadataBase: new URL(site.url),
+  title: "williamhzo.com",
   description:
     "Passionate & user-focused Product Engineer with a keen eye for design, crafting high impact products.",
+  alternates: {
+    canonical: "/",
+  },
   icons:
     "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐡</text></svg>",
 };

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -6,6 +6,9 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Notes",
   description: "Writing about web development, design, and building products.",
+  alternates: {
+    canonical: "/notes",
+  },
 };
 
 export default async function NotesPage() {

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from "next/og";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { site } from "@/constants";
 
 export const alt = "william — product engineer";
 export const size = {
@@ -33,10 +34,10 @@ export default async function Image() {
       >
         <div style={{ display: "flex", flexDirection: "column" }}>
           <div style={{ fontSize: 32, color: "#697282", fontWeight: 600 }}>
-            williamhzo.me
+            {site.domain}
           </div>
           <div style={{ fontSize: 40 }}>
-            product engineer, builder & learner
+            product engineer, AI builder & learner
           </div>
         </div>
       </div>

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { site } from "@/constants";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -7,6 +8,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: "/private/",
     },
-    sitemap: "https://williamhzo.me/sitemap.xml",
+    sitemap: `${site.url}/sitemap.xml`,
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,9 +1,10 @@
 import type { MetadataRoute } from "next";
+import { site } from "@/constants";
 import { POSTS } from "@/lib/blog";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const posts = POSTS.map((post) => ({
-    url: `https://williamhzo.me/${post.slug}`,
+    url: `${site.url}/${post.slug}`,
     lastModified: new Date(),
     changeFrequency: "yearly" as const,
     priority: 0.5,
@@ -11,13 +12,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   return [
     {
-      url: "https://williamhzo.me",
+      url: site.url,
       lastModified: new Date(),
       changeFrequency: "yearly",
       priority: 1,
     },
     {
-      url: "https://williamhzo.me/notes",
+      url: `${site.url}/notes`,
       lastModified: new Date(),
       changeFrequency: "yearly",
       priority: 0.8,

--- a/constants.ts
+++ b/constants.ts
@@ -11,3 +11,8 @@ export const paths = {
   deca: "https://deca.art",
   shape: "https://shape.network",
 };
+
+export const site = {
+  url: "https://www.williamhzo.com",
+  domain: "www.williamhzo.com",
+};

--- a/content/blog-paralysis.mdx
+++ b/content/blog-paralysis.mdx
@@ -2,11 +2,11 @@ export const metadata = {
   title: 'Unlocking the "blog paralysis"',
   publishedDate: "2023-01-10",
   description: "On changing mindset about publishing blog posts.",
-  canonicalUrl: "https://williamhzo.me/blog-paralysis",
+  canonicalUrl: "https://www.williamhzo.com/blog-paralysis",
   publish: true,
 };
 
-As mentioned in a [previous post](https://williamhzo.me/writing), I’ve started a blog. Surfing on the fact that 2023 is ["the year of blogging"](https://chriscoyier.net/2022/12/26/bring-back-blogging/) and more generally ["the year of personal websites"](https://matthiasott.com/notes/the-year-of-the-personal-website), I’m trying to get in the habit of writing here. Most posts will be about some web development and design-related stuff that I learn along the way. It will sometimes get more personal (just like this very post 🙃), as this is — after all — my very own little space on the web.
+As mentioned in a [previous post](https://www.williamhzo.com/writing), I’ve started a blog. Surfing on the fact that 2023 is ["the year of blogging"](https://chriscoyier.net/2022/12/26/bring-back-blogging/) and more generally ["the year of personal websites"](https://matthiasott.com/notes/the-year-of-the-personal-website), I’m trying to get in the habit of writing here. Most posts will be about some web development and design-related stuff that I learn along the way. It will sometimes get more personal (just like this very post 🙃), as this is — after all — my very own little space on the web.
 
 Almost a month after shipping this website and its first blog post, I still find myself struggling with writing and publishing. Whenever I take time to focus on writing I find myself overthinking _a lot_. I re-read every sentence a few times, iterate, and eventually end up questioning the relevance of the topic I’m writing on.
 

--- a/content/pixel-perfect.mdx
+++ b/content/pixel-perfect.mdx
@@ -2,7 +2,7 @@ export const metadata = {
   title: 'Letting go of "pixel-perfect"',
   publishedDate: "2023-01-20",
   description: "On building dynamic web experiences from static designs.",
-  canonicalUrl: "https://williamhzo.me/pixel-perfect",
+  canonicalUrl: "https://www.williamhzo.com/pixel-perfect",
   publish: true,
 };
 

--- a/content/shape.mdx
+++ b/content/shape.mdx
@@ -2,7 +2,7 @@ export const metadata = {
   title: "Building on Shape",
   publishedDate: "2025-07-16",
   description: "On how to get started building on Shape.",
-  canonicalUrl: "https://williamhzo.me/shape",
+  canonicalUrl: "https://www.williamhzo.com/shape",
   publish: true,
 };
 

--- a/content/writing.mdx
+++ b/content/writing.mdx
@@ -2,7 +2,7 @@ export const metadata = {
   title: "Writing on the web",
   publishedDate: "2022-12-19",
   description: 'The obligatory first blog post — or "Hello world".',
-  canonicalUrl: "https://williamhzo.me/writing",
+  canonicalUrl: "https://www.williamhzo.com/writing",
   publish: true,
 };
 


### PR DESCRIPTION
## What
- switch the site metadata base, sitemap, robots, and canonical tags to `https://www.williamhzo.com`
- emit canonical/open graph URLs for note detail pages from post metadata
- update post frontmatter canonicals and internal post links to the new `.com` host
- refresh the OG card domain label to match the new canonical host

## Why
- make `.com` the single canonical host before redirecting `.me`
- preserve SEO continuity during the Vercel domain cutover
- avoid split indexing between old and new domains

## Validation
- `bun run lint`
- `bun run build`